### PR TITLE
Add draft Multichain API MIPs

### DIFF
--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -15,7 +15,7 @@ This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional spec
 ## Motivation
 Developers building against Ethereum-compatible networks stand to benefit the most from the simplified developer experience associated with the Multichain API. 
 
-The Multichain API and associated CAIP standards promise to enable the following benefits for these developers:
+The Multichain API will enable the following benefits for developers:
 - Elimination of excessive error handling involved with chain-switching across EVM networks
 - Employ interface negotiation patterns to adopt novel wallet features, while gracefully degrading for wallets that may not yet support them
 - Ability to simultaneously interact with multiple networks

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -123,7 +123,7 @@ Valid CAIP-217 `scopeStrings` for EVM networks shall include (and will, initiall
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
 
 ### Valid scopedProperties
-When a MetaMask user does not have an existing network configured for a given `eip155[reference]` scope, including metadata for `rpcEndpoints` in the `scopedProperties` serves as a suggestion for the user to add the RPC network. MetaMask will expect the `rpcEndpoints` parameter to conform with the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard.
+A dapp may include metadata for `rpcEndpoints` in the `scopedProperties` object to suggest (and provide the required networkConfiguration for) the addition of a given network which the wallet instance does not yet have installed. MetaMask will expect the `rpcEndpoints` parameter to conform to the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard interface.
 
 > **Note:** MetaMask does not yet support prompting for RPC additions as part of the [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) connection flow, but may do so in the future. 
 

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -10,7 +10,7 @@ created: 2024-10-28
 ---
 
 ## Summary
-This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional specifications for Ethereum-compatible networks.
+This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional specifications for EVM networks.
 
 ## Motivation
 Developers building against Ethereum-compatible networks stand to benefit the most from the simplified developer experience associated with the Multichain API. 

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -89,7 +89,7 @@ An example structure for the corresponding JSON-RPC response that an application
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
         "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:59144": {

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -16,10 +16,9 @@ This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional spec
 Developers building against Ethereum-compatible networks stand to benefit the most from the simplified developer experience associated with the Multichain API. 
 
 The Multichain API will enable the following benefits for developers:
-- Elimination of excessive error handling involved with chain-switching across EVM networks
-- Employ interface negotiation patterns to adopt novel wallet features, while gracefully degrading for wallets that may not yet support them
-- Ability to simultaneously interact with multiple networks
-- Be notified of updates across multiple networks
+- Concurrent cross chain state reading
+- Elimination of chain switching
+- Improved connection flows, with better interfaces for dapps to understand wallet capabilities and add missing networks on the fly.
 
 ## Usage Example
 ### Request

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -117,7 +117,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 `scopeObjects` must conform to [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)
 
-Valid CAIP-217 `scopeStrings` for Ethereum-compatible networks shall include and will initially be limited to:
+Valid CAIP-217 `scopeStrings` for EVM networks shall include (and will, initially, be limited to):
 - `wallet` - for general authorizations that are unrelated to a specific network or `namespace`
 - `wallet:eip155` - for authorizations that are particular to the `eip155` `namespace`, but involve a function that is not specific to a particular network
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -17,7 +17,7 @@ Developers building against Ethereum-compatible networks stand to benefit the mo
 
 The Multichain API and associated CAIP standards promise to enable the following benefits for these developers:
 - Elimination of excessive error handling involved with chain-switching across EVM networks
-- Ability to use interface negotiation to adopt innovative wallet features, while gracefully degrading for wallets that may not yet support them
+- Employ interface negotiation patterns to adopt novel wallet features, while gracefully degrading for wallets that may not yet support them
 - Ability to simultaneously interact with multiple networks
 - Be notified of updates across multiple networks
 

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -44,21 +44,23 @@ An example structure for a JSON-RPC request that an application would send to re
         "notifications": ["message"],
       },
     },
-    "scopedProperties": {
-      "eip155:1": {
-        "rpcEndpoints": [{ 
-          "chainName": "Ethereum (Infura)",
+"scopedProperties": {
+  "eip155:1": {
+    "eip3085": {
+          "rpcEndpoints": [{
+            "chainName": "Ethereum (Infura)",
           "rpcUrls": ["https://mainnet.infura.io"],
           "nativeCurrency": {
               "name": "ETH",
               "symbol": "ETH",
               "decimals": 18,
           },
-          "iconURLs": ["https://example.com/ethereum.svg"] 
-        }],  
+          "iconURLs": ["https://example.com/ethereum.svg"]
+        }],
       },
       "eip155:59144": {
-        "rpcEndpoints": [{ 
+        "eip3085": {
+          "rpcEndpoints": [{
           "chainName": "Linea (Infura)",
           "rpcUrls": ["https://rpc.linea.build"],
           "nativeCurrency": {
@@ -66,12 +68,12 @@ An example structure for a JSON-RPC request that an application would send to re
               "symbol": "ETH",
               "decimals": 18,
           },
-          "iconURLs": ["https://example.com/linea.svg"] 
+          "iconURLs": ["https://example.com/linea.svg"]
         }],
       },
     },
   },
-}
+};
 ```
 
 ### Response

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -5,7 +5,7 @@ status: Draft
 stability: n/a
 discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions
 author(s): Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
-type: Community
+type: Maintainer
 created: 2023-04-28
 ---
 

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -46,30 +46,26 @@ An example structure for a JSON-RPC request that an application would send to re
     },
     "scopedProperties": {
       "eip155:1": {
-        "eip3085": {
-          "rpcEndpoints": [{
-            "chainName": "Ethereum (Infura)",
-            "rpcUrls": ["https://mainnet.infura.io"],
-            "nativeCurrency": {
-                "name": "ETH",
-                "symbol": "ETH",
-                "decimals": 18,
-            },
-          }],
-        },
+        "eip3085": [
+          "chainName": "Ethereum (Infura)",
+          "rpcUrls": ["https://mainnet.infura.io"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+        ],
       },
       "eip155:59144": {
-        "eip3085": {
-          "rpcEndpoints": [{
-            "chainName": "Linea (Infura)",
-            "rpcUrls": ["https://rpc.linea.build"],
-            "nativeCurrency": {
-                "name": "ETH",
-                "symbol": "ETH",
-                "decimals": 18,
-            },
-          }],
-        },
+        "eip3085": [
+          "chainName": "Linea (Infura)",
+          "rpcUrls": ["https://rpc.linea.build"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+        ],
       },
     },
   },

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -1,0 +1,146 @@
+---
+mip: x
+title: Multichain API for Ethereum
+status: Draft
+stability: n/a
+discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions
+author(s): Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
+type: Community
+created: 2023-04-28
+---
+
+## Summary
+This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional specifications for Ethereum-compatible networks.
+
+## Motivation
+Developers building against Ethereum-compatible networks stand to benefit the most from the simplified developer experience associated with the Multichain API. 
+
+The Multichain API and associated CAIP standards promise to enable the following benefits for these developers:
+- Elimination of excessive error handling involved with chain-switching across EVM networks
+- Ability to use interface negotiation to adopt innovative wallet features, while gracefully degrading for wallets that may not yet support them
+- Ability to simultaneously interact with multiple networks
+- Be notified of updates across multiple networks
+
+## Usage Example
+### Request
+An example structure for a JSON-RPC request that an application would send to request authorization(s) from MetaMask:
+
+```js
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_createSession",
+  "params": {
+    "optionalScopes": {
+      "wallet:eip155": {
+        "methods": ["wallet_addEthereumChain"],
+      },
+      "eip155:1": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+      },
+      "eip155:59144": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+      },
+    },
+    "scopedProperties": {
+      "eip155:1": {
+        "rpcEndpoints": [{ 
+          "chainName": "Ethereum (Infura)",
+          "rpcUrls": ["https://mainnet.infura.io"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+          "iconURLs": ["https://example.com/ethereum.svg"] 
+        }],  
+      },
+      "eip155:59144": {
+        "rpcEndpoints": [{ 
+          "chainName": "Linea (Infura)",
+          "rpcUrls": ["https://rpc.linea.build"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+          "iconURLs": ["https://example.com/linea.svg"] 
+        }],
+      },
+    },
+  },
+}
+```
+
+### Response
+An example structure for the corresponding JSON-RPC response that an application would receive from the wallet:
+
+```js
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "sessionScopes": { 
+      "eip155:wallet": {
+          "methods": ["wallet_addEthereumChain"],
+          "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "eip155:1": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+        "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "eip155:59144": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+        "accounts": ["eip155:59144:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+    },      
+  }
+}
+```
+
+# Proposal
+
+## Language
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written in uppercase in this document are to be interpreted as described in RFC 2119.
+
+## Definitions
+
+
+## Proposal Specification
+
+
+### API Specification Document
+An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
+
+## Caveats
+[List any potential drawbacks, limitations, or risks associated with the proposal]
+
+## Implementation
+[Outline how the proposal will be implemented. Which party is expected to implement the proposal?]
+
+## Developer Adoption Considerations
+[Explain any considerations that developers should take into account when adopting this proposal. For example, how will it affect compatibility, and what changes may need to be made to accommodate the proposal?]
+
+## User Experience Considerations
+[Explain any user experience implications of the proposal]
+
+## Security Considerations
+[Explain any potential security implications of the proposal]
+
+## References
+[List any relevant resources, documentation, or prior art]
+
+### Feedback
+[Provide a way for interested parties to give feedback or make suggestions, such as a GitHub issue or discussion thread]
+
+### Committed Developers
+[List the names of developers who have committed to using this proposal in an experimental state. This will help gauge community interest and adoption.]
+
+Note: This proposal template is meant to be adapted for different contexts and may require additional sections or information depending on the specific proposal.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -94,7 +94,7 @@ An example structure for the corresponding JSON-RPC response that an application
       },
       "eip155:59144": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
         "accounts": ["eip155:59144:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
     },      

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -112,21 +112,38 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Proposal Specification
 
+### Valid scopeStrings
+
+`scopeObjects` must conform to [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)
+
+Valid CAIP-217 `scopeStrings` SHALL include and will initially be limited to:
+- `wallet` - for general authorizations that are unrelated to a specific network or `namespace`
+- `wallet:eip155` - for authorizations that are particular to the `eip155` `namespace`, but involve a function that is not specific to a particular network
+- `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
 
 ### API Specification Document
 An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
 
 ## Caveats
-[List any potential drawbacks, limitations, or risks associated with the proposal]
+
+
 
 ## Implementation
-[Outline how the proposal will be implemented. Which party is expected to implement the proposal?]
+API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.
 
 ## Developer Adoption Considerations
-[Explain any considerations that developers should take into account when adopting this proposal. For example, how will it affect compatibility, and what changes may need to be made to accommodate the proposal?]
+For Ethereum networks, backward compatibility will be maintained through the existing Ethereum Provider API (namely [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326)).
+Because many developers rely on third-party libraries to connect their applications with wallets, mapping logic that allows them to keep their "single chain" code as-is while actually passing calls on to an underlying Multichain API may facilitate more rapid adoption. 
+
+Given its flexibility and advantages, developers should expect new improvements to the Wallet API to be primarily delivered though the Multichain API, as opposed to the [Ethereum Provider API](https://docs.metamask.io/wallet/reference/provider-api/).
+
+Once there is sufficient industry adoption of the Multichain API, backward-compatibility may be gradually deprecated and discontinued.
 
 ## User Experience Considerations
 [Explain any user experience implications of the proposal]
+
+## Privacy Considerations
+This proposal raises important privacy considerations, including the need to avoid data leaking and the challenge of obtaining genuine user consent. It underscores the importance of preserving user anonymity and the sensitivites involved in determining authorizations. Identifying and mitigating these issues is crucial for protecting user privacy during multichain interactions, prompting a careful evaluation of how best to balance functionality with privacy concerns.
 
 ## Security Considerations
 [Explain any potential security implications of the proposal]
@@ -135,12 +152,10 @@ An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/ap
 [List any relevant resources, documentation, or prior art]
 
 ### Feedback
-[Provide a way for interested parties to give feedback or make suggestions, such as a GitHub issue or discussion thread]
+Submit feedback in the [discussion](https://github.com/MetaMask/metamask-improvement-proposals/discussions/53) for this MIP.
 
 ### Committed Developers
-[List the names of developers who have committed to using this proposal in an experimental state. This will help gauge community interest and adoption.]
-
-Note: This proposal template is meant to be adapted for different contexts and may require additional sections or information depending on the specific proposal.
+MetaMask
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE).

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -137,17 +137,18 @@ An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/ap
 While most methods from the existing API will also be available on the Multichain API, the new API renders some methods and notifications redundant or incompatible. The following methods will not be supported through the Multichain API. However, they will remain accessible through the injected [EIP-1193][eip-1193] API for backwards compatibility.
 
 **Discontinued Methods:**
-eth_requestAccounts
-eth_chainId
-eth_getEncryptionPublicKey
-eth_decrypt
-eth_accounts
-wallet_getPermissions
-wallet_requestPermissions
-wallet_revokePermissions
-wallet_switchEthereumChain
-eth_signTypedData
-eth_signTypedData_v3
+- eth_requestAccounts
+- eth_chainId
+- eth_getEncryptionPublicKey
+- eth_decrypt
+- eth_accounts
+- wallet_getPermissions
+- wallet_requestPermissions
+- wallet_revokePermissions
+- wallet_switchEthereumChain
+- eth_signTypedData
+- eth_signTypedData_v3
+
 
 **Discontinued Events:**
 - connect

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -118,7 +118,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 `scopeObjects` must conform to [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)
 
 Valid CAIP-217 `scopeStrings` for EVM networks shall include (and will, initially, be limited to):
-- `wallet` - for general authorizations that are unrelated to a specific network or `namespace`
+- `wallet` - for methods that are not specific to a network or [CASA namespace][casa-namespaces] (e.g. `wallet_scanQRCode`)
 - `wallet:eip155` - for authorizations that are particular to the `eip155` `namespace`, but involve a function that is not specific to a particular network
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
 

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -41,7 +41,7 @@ An example structure for a JSON-RPC request that an application would send to re
       },
       "eip155:59144": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
       },
     },
     "scopedProperties": {

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -119,7 +119,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Valid CAIP-217 `scopeStrings` for EVM networks shall include (and will, initially, be limited to):
 - `wallet` - for methods that are not specific to a network or [CASA namespace][casa-namespaces] (e.g. `wallet_scanQRCode`)
-- `wallet:eip155` - for authorizations that are particular to the `eip155` `namespace`, but involve a function that is not specific to a particular network
+- `wallet:eip155` - for methods that are particular to EVM networks (e.g. the `eip155` namespace), but do not target a specific network (e.g. `wallet_addEthereumChain`)
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
 
 ### Valid scopedProperties

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -55,21 +55,19 @@ An example structure for a JSON-RPC request that an application would send to re
                 "symbol": "ETH",
                 "decimals": 18,
             },
-            "iconURLs": ["https://example.com/ethereum.svg"]
           }],
         },
       },
       "eip155:59144": {
         "eip3085": {
           "rpcEndpoints": [{
-          "chainName": "Linea (Infura)",
-          "rpcUrls": ["https://rpc.linea.build"],
-          "nativeCurrency": {
-              "name": "ETH",
-              "symbol": "ETH",
-              "decimals": 18,
-          },
-          "iconURLs": ["https://example.com/linea.svg"]
+            "chainName": "Linea (Infura)",
+            "rpcUrls": ["https://rpc.linea.build"],
+            "nativeCurrency": {
+                "name": "ETH",
+                "symbol": "ETH",
+                "decimals": 18,
+            },
           }],
         },
       },
@@ -155,6 +153,7 @@ While most methods from the existing API will also be available on the Multichai
 - disconnect
 - chainChanged
 - accountsChanged
+- message
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -109,24 +109,43 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Definitions
 
-
 ## Proposal Specification
 
 ### Valid scopeStrings
 
 `scopeObjects` must conform to [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)
 
-Valid CAIP-217 `scopeStrings` SHALL include and will initially be limited to:
+Valid CAIP-217 `scopeStrings` for Ethereum-compatible networks shall include and will initially be limited to:
 - `wallet` - for general authorizations that are unrelated to a specific network or `namespace`
 - `wallet:eip155` - for authorizations that are particular to the `eip155` `namespace`, but involve a function that is not specific to a particular network
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
+
+### Valid scopedProperties
+When a MetaMask user does not have an existing network configured for a given `eip155[reference]` scope, including metadata for `rpcEndpoints` in the `scopeMetadata` serves as a suggestion for the user add the first endpoint in the list. MetaMask will expect the `rpcEndpoints` parameter to conform with the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard.
+
+> **Note:** MetaMask does not yet support prompting for RPC additions as part of the [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) connection flow, but may do so in the future. 
 
 ### API Specification Document
 An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
 
 ## Caveats
+While most existing Ethereum methods will be familiar under the Multichain API, the new API renders some standard methods and events either redundant or incompatible with the new interaction patterns. The following Ethereum standards will not be supported through the Multichain API. However, they will remain accessible through the EIP-1193 interface for backward compatibility.
 
+**Discontinued Methods:**
+eth_requestAccounts
+eth_accounts
+wallet_getPermissions
+wallet_requestPermissions
+wallet_revokePermissions
+wallet_switchEthereumChain
+eth_signTypedData
+eth_signTypedData_v3
 
+**Discontinued Events:**
+- connect
+- disconnect
+- chainChanged
+- accountsChanged
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -121,7 +121,7 @@ Valid CAIP-217 `scopeStrings` for Ethereum-compatible networks shall include and
 - `eip155:[reference]` - for chain-specific authorizations using a [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) identifier with both an `eip155` `namespace` and `reference`
 
 ### Valid scopedProperties
-When a MetaMask user does not have an existing network configured for a given `eip155[reference]` scope, including metadata for `rpcEndpoints` in the `scopeMetadata` serves as a suggestion for the user add the first endpoint in the list. MetaMask will expect the `rpcEndpoints` parameter to conform with the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard.
+When a MetaMask user does not have an existing network configured for a given `eip155[reference]` scope, including metadata for `rpcEndpoints` in the `scopedProperties` serves as a suggestion for the user to add the RPC network. MetaMask will expect the `rpcEndpoints` parameter to conform with the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard.
 
 > **Note:** MetaMask does not yet support prompting for RPC additions as part of the [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) connection flow, but may do so in the future. 
 
@@ -157,18 +157,6 @@ Because many developers rely on third-party libraries to connect their applicati
 Given its flexibility and advantages, developers should expect new improvements to the Wallet API to be primarily delivered though the Multichain API, as opposed to the [Ethereum Provider API](https://docs.metamask.io/wallet/reference/provider-api/).
 
 Once there is sufficient industry adoption of the Multichain API, backward-compatibility may be gradually deprecated and discontinued.
-
-## User Experience Considerations
-[Explain any user experience implications of the proposal]
-
-## Privacy Considerations
-This proposal raises important privacy considerations, including the need to avoid data leaking and the challenge of obtaining genuine user consent. It underscores the importance of preserving user anonymity and the sensitivites involved in determining authorizations. Identifying and mitigating these issues is crucial for protecting user privacy during multichain interactions, prompting a careful evaluation of how best to balance functionality with privacy concerns.
-
-## Security Considerations
-[Explain any potential security implications of the proposal]
-
-## References
-[List any relevant resources, documentation, or prior art]
 
 ### Feedback
 Submit feedback in the [discussion](https://github.com/MetaMask/metamask-improvement-proposals/discussions/53) for this MIP.

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -84,7 +84,7 @@ An example structure for the corresponding JSON-RPC response that an application
       "wallet:eip155": {
           "methods": ["wallet_addEthereumChain"],
           "notifications": [],
-          "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+          "accounts": ["wallet:eip155:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:1": {
         "methods": ["wallet_watchAsset","eth_sendTransaction","personal_sign","eth_signTypedData_v4","web3_clientVersion","eth_subscribe","eth_unsubscribe", "eth_blockNumber", "eth_call","eth_estimateGas","eth_feeHistory","eth_gasPrice","eth_getBalance","eth_getBlockByHash","eth_getBlockByNumber","eth_getBlockTransactionCountByHash","eth_getBlockTransactionCountByNumber","eth_getCode","eth_getFilterChanges","eth_getFilterLogs","eth_getLogs","eth_getProof","eth_getStorageAt","eth_getTransactionByBlockHashAndIndex","eth_getTransactionByBlockNumberAndIndex","eth_getTransactionByHash","eth_getTransactionCount","eth_getTransactionReceipt","eth_getUncleCountByBlockHash","eth_getUncleCountByBlockNumber","eth_newBlockFilter","eth_newFilter","eth_newPendingTransactionFilter","eth_sendRawTransaction","eth_syncing","eth_uninstallFilter"],

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -132,28 +132,28 @@ A dapp may include metadata for `rpcEndpoints` in the `scopedProperties` object 
 An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
 
 ## Caveats
-While most methods from the existing API will also be available on the Multichain API, the new API renders some methods and notifications redundant or incompatible. The following methods will not be supported through the Multichain API. However, they will remain accessible through the injected [EIP-1193][eip-1193] API for backwards compatibility.
+While most methods from the existing API will also be available on the Multichain API, the new API renders some methods and notifications redundant or incompatible. The following methods will not be supported through the Multichain API. However, they will remain accessible through the injected [EIP-1193][https://eips.ethereum.org/EIPS/eip-1193] API for backwards compatibility.
 
 **Discontinued Methods:**
-- eth_requestAccounts
-- eth_chainId
-- eth_getEncryptionPublicKey
-- eth_decrypt
-- eth_accounts
-- wallet_getPermissions
-- wallet_requestPermissions
-- wallet_revokePermissions
-- wallet_switchEthereumChain
-- eth_signTypedData
-- eth_signTypedData_v3
+- `eth_requestAccounts`
+- `eth_chainId`
+- `eth_getEncryptionPublicKey`
+- `eth_decrypt`
+- `eth_accounts`
+- `wallet_getPermissions`
+- `wallet_requestPermissions`
+- `wallet_revokePermissions`
+- `wallet_switchEthereumChain`
+- `eth_signTypedData`
+- `eth_signTypedData_v3`
 
 
 **Discontinued Events:**
-- connect
-- disconnect
-- chainChanged
-- accountsChanged
-- message
+- `connect`
+- `disconnect`
+- `chainChanged`
+- `accountsChanged`
+- `message`
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -13,7 +13,7 @@ created: 2024-10-28
 This proposal supplements [MIP-x](./mip-x-multichainapi.md) with additional specifications for EVM networks.
 
 ## Motivation
-Developers building against Ethereum-compatible networks stand to benefit the most from the simplified developer experience associated with the Multichain API. 
+Current single chain EVM Wallet APIs severely limit EVM dapp development and cause a great deal of unnecessary friction for users operating in an ecosystem with rapidly growing number of chains. As such, Dapp developers and end users stand to benefit tremendously from the improved DevEx and UX that the Multichain API will provide. 
 
 The Multichain API will enable the following benefits for developers:
 - Concurrent cross chain state reading

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -125,13 +125,13 @@ Valid CAIP-217 `scopeStrings` for EVM networks shall include (and will, initiall
 ### Valid scopedProperties
 A dapp may include metadata for `rpcEndpoints` in the `scopedProperties` object to suggest (and provide the required networkConfiguration for) the addition of a given network which the wallet instance does not yet have installed. MetaMask will expect the `rpcEndpoints` parameter to conform to the [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) standard interface.
 
-> **Note:** MetaMask does not yet support prompting for RPC additions as part of the [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) connection flow, but may do so in the future. 
+> **Note:** MetaMask does not yet support network additions via the [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) connection flow, but will in the future. 
 
 ### API Specification Document
 An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
 
 ## Caveats
-While most existing Ethereum methods will be familiar under the Multichain API, the new API renders some standard methods and events either redundant or incompatible with the new interaction patterns. The following Ethereum standards will not be supported through the Multichain API. However, they will remain accessible through the EIP-1193 interface for backward compatibility.
+While most methods from the existing API will also be available on the Multichain API, the new API renders some methods and notifications redundant or incompatible. The following methods will not be supported through the Multichain API. However, they will remain accessible through the injected [EIP-1193][eip-1193] API for backwards compatibility.
 
 **Discontinued Methods:**
 eth_requestAccounts
@@ -153,12 +153,12 @@ eth_signTypedData_v3
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.
 
 ## Developer Adoption Considerations
-For Ethereum networks, backward compatibility will be maintained through the existing Ethereum Provider API (namely [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326)).
+For EVM networks, backward compatibility will be maintained through the existing injected `window.ethereum` API (namely [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326)).
 Because many developers rely on third-party libraries to connect their applications with wallets, mapping logic that allows them to keep their "single chain" code as-is while actually passing calls on to an underlying Multichain API may facilitate more rapid adoption. 
 
 Given its flexibility and advantages, developers should expect new improvements to the Wallet API to be primarily delivered though the Multichain API, as opposed to the [Ethereum Provider API](https://docs.metamask.io/wallet/reference/provider-api/).
 
-Once there is sufficient industry adoption of the Multichain API, backward-compatibility may be gradually deprecated and discontinued.
+Once there is sufficient industry adoption of the Multichain API, the injected provider may be deprecated.
 
 ### Feedback
 Submit feedback in the [discussion](https://github.com/MetaMask/metamask-improvement-proposals/discussions/53) for this MIP.

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -89,6 +89,7 @@ An example structure for the corresponding JSON-RPC response that an application
     "sessionScopes": { 
       "eip155:wallet": {
           "methods": ["wallet_addEthereumChain"],
+          "notifications": [],
           "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:1": {

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -33,6 +33,7 @@ An example structure for a JSON-RPC request that an application would send to re
     "optionalScopes": {
       "wallet:eip155": {
         "methods": ["wallet_addEthereumChain"],
+        "notifications": [],
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -43,19 +43,20 @@ An example structure for a JSON-RPC request that an application would send to re
         "notifications": ["message"],
       },
     },
-"scopedProperties": {
-  "eip155:1": {
-    "eip3085": {
+    "scopedProperties": {
+      "eip155:1": {
+        "eip3085": {
           "rpcEndpoints": [{
             "chainName": "Ethereum (Infura)",
-          "rpcUrls": ["https://mainnet.infura.io"],
-          "nativeCurrency": {
-              "name": "ETH",
-              "symbol": "ETH",
-              "decimals": 18,
-          },
-          "iconURLs": ["https://example.com/ethereum.svg"]
-        }],
+            "rpcUrls": ["https://mainnet.infura.io"],
+            "nativeCurrency": {
+                "name": "ETH",
+                "symbol": "ETH",
+                "decimals": 18,
+            },
+            "iconURLs": ["https://example.com/ethereum.svg"]
+          }],
+        },
       },
       "eip155:59144": {
         "eip3085": {
@@ -68,7 +69,8 @@ An example structure for a JSON-RPC request that an application would send to re
               "decimals": 18,
           },
           "iconURLs": ["https://example.com/linea.svg"]
-        }],
+          }],
+        },
       },
     },
   },
@@ -89,12 +91,12 @@ An example structure for the corresponding JSON-RPC response that an application
           "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:1": {
-        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "methods": ["wallet_watchAsset","eth_sendTransaction","personal_sign","eth_signTypedData_v4","web3_clientVersion","eth_subscribe","eth_unsubscribe", "eth_blockNumber", "eth_call","eth_estimateGas","eth_feeHistory","eth_gasPrice","eth_getBalance","eth_getBlockByHash","eth_getBlockByNumber","eth_getBlockTransactionCountByHash","eth_getBlockTransactionCountByNumber","eth_getCode","eth_getFilterChanges","eth_getFilterLogs","eth_getLogs","eth_getProof","eth_getStorageAt","eth_getTransactionByBlockHashAndIndex","eth_getTransactionByBlockNumberAndIndex","eth_getTransactionByHash","eth_getTransactionCount","eth_getTransactionReceipt","eth_getUncleCountByBlockHash","eth_getUncleCountByBlockNumber","eth_newBlockFilter","eth_newFilter","eth_newPendingTransactionFilter","eth_sendRawTransaction","eth_syncing","eth_uninstallFilter"],
         "notifications": ["eth_subscription"],
         "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:59144": {
-        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "methods": ["wallet_watchAsset","eth_sendTransaction","personal_sign","eth_signTypedData_v4","web3_clientVersion","eth_subscribe","eth_unsubscribe", "eth_blockNumber", "eth_call","eth_estimateGas","eth_feeHistory","eth_gasPrice","eth_getBalance","eth_getBlockByHash","eth_getBlockByNumber","eth_getBlockTransactionCountByHash","eth_getBlockTransactionCountByNumber","eth_getCode","eth_getFilterChanges","eth_getFilterLogs","eth_getLogs","eth_getProof","eth_getStorageAt","eth_getTransactionByBlockHashAndIndex","eth_getTransactionByBlockNumberAndIndex","eth_getTransactionByHash","eth_getTransactionCount","eth_getTransactionReceipt","eth_getUncleCountByBlockHash","eth_getUncleCountByBlockNumber","eth_newBlockFilter","eth_newFilter","eth_newPendingTransactionFilter","eth_sendRawTransaction","eth_syncing","eth_uninstallFilter"],
         "notifications": ["eth_subscription"],
         "accounts": ["eip155:59144:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
@@ -134,6 +136,9 @@ While most methods from the existing API will also be available on the Multichai
 
 **Discontinued Methods:**
 eth_requestAccounts
+eth_chainId
+eth_getEncryptionPublicKey
+eth_decrypt
 eth_accounts
 wallet_getPermissions
 wallet_requestPermissions

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -37,7 +37,7 @@ An example structure for a JSON-RPC request that an application would send to re
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
       },
       "eip155:59144": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -3,7 +3,7 @@ mip: x
 title: Multichain API for Ethereum
 status: Draft
 stability: n/a
-discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions
+discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions/53
 author(s): Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
 type: Maintainer
 created: 2024-10-28

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -81,7 +81,7 @@ An example structure for the corresponding JSON-RPC response that an application
   "jsonrpc": "2.0",
   "result": {
     "sessionScopes": { 
-      "eip155:wallet": {
+      "wallet:eip155": {
           "methods": ["wallet_addEthereumChain"],
           "notifications": [],
           "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]

--- a/MIPs/mip-x-evmmultichainapi.md
+++ b/MIPs/mip-x-evmmultichainapi.md
@@ -6,7 +6,7 @@ stability: n/a
 discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions
 author(s): Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
 type: Maintainer
-created: 2023-04-28
+created: 2024-10-28
 ---
 
 ## Summary

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -81,7 +81,7 @@ An example structure for the corresponding JSON-RPC response that a dapp would r
       "wallet:eip155": {
           "methods": ["wallet_addEthereumChain"],
           "notifications": [],
-          "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+          "accounts": ["wallet:eip155:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -16,8 +16,8 @@ This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement
 - Consistent Structure: Provide common patterns while separating namespaces of each ecosystem or network.
 - Interoperability: Employ standards to encourage the development of powerful libraries with support for multiple wallets and networks.
 - Unlock the Design Space: Enable dapps to negotiate an interface with wallets for optimal multichain experiences.
-- Extensibility: Make the API reasonbaly future-proof, allowing for new networks and methods to be added as demanded by the ecosystem.
-- Security: Enhance security and privacy associated with wallets delived through Browser Extensions.
+- Extensibility: Make the API reasonably future-proof, allowing for new networks and methods to be added as demanded by the ecosystem.
+- Security: Enhance security and privacy associated with wallets delivered through Browser Extensions.
 
 ## Motivation
 Valuable lessons have been learned from scaling the Ethereum dapp and wallet ecosystem. Now, a subset of [CAIPs](https://github.com/ChainAgnostic/CAIPs) offer a path to dramatically improve upon the prevailing patterns that had been established through [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326) with chain-agnostic patterns that address long-standing issues. Furthermore, as decentralized networks continue to diversify, these patterns can be applied to non-EVM ecosystems so they can scale more efficiently and avoid common pain points associated with the demands of a growing dapp ecosystem that may require rapid evolution of Wallet APIs.

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -188,7 +188,7 @@ API Maintainers will implement the multichain interface in coordination with mul
 The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26](https://github.com/MetaMask/SIPs/blob/ed17dd33713e6c2203f11b85ba655ae4acbcca7a/SIPS/sip-26.md) for a high-level overview of the anticipated architectural approach.
 
 ## Developer Adoption Considerations
-dapp developers are encouraged to use libraries to abstract the connection differences between wallet clients and to ensure their dapp stays updated as wallet-to-dapp communication methods continue to evolve.
+Dapp developers are encouraged to use libraries to abstract the connection differences between wallet clients and to ensure their dapp stays updated as wallet-to-dapp communication methods continue to evolve.
 
 ## User Experience Considerations
 Initial calls to the `wallet_authorize` method with `optionalScopes` that include any eip155:[reference] scopes will trigger a flow with this sequence:

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -147,10 +147,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Proposal Specification
 
-As part of MetaMask's Multichain API implementation, MetaMask will adopt the following standards with notes for implementation-specific guidelines or differences:
+As part of MetaMask's Multichain API implementation, MetaMask will adopt the following standards noting implementation-specific guidelines or differences:
 
 ### CAIP-2 - Network Identifiers
-The network identifiers used in the routing of Multichain API calls will follow [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) conventions and [namespaces](https://namespaces.chainagnostic.org/).
+The network identifiers used in the routing of Multichain API calls will generally follow [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) conventions and [namespaces](https://github.com/ChainAgnostic/namespaces). However, network identifiers may be extended directly through Snaps and may not be limited to [Chain Agnostic Namespaces](https://namespaces.chainagnostic.org/).
 
 > **Note:** Supported namespaces may be limited. Consult the [MetaMask documentation](https://docs.metamask.io/wallet/reference/multichain-api) for the most up-to-date information.
 
@@ -158,6 +158,8 @@ The network identifiers used in the routing of Multichain API calls will follow 
 Multichain API connections will be established and updated through [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) `wallet_createSession` calls.
 
 > **Note:** A `sessionId` will not be returned in the initial response. Instead, the API will adopt session lifecycle management methods outlined in [CAIP-316](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-316.md)
+
+> **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. We only recommend using `optionalScopes`, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized.
 
 ### CAIP-312 - Retrieve Authorization Scopes
 An app can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
@@ -185,16 +187,45 @@ API Maintainers will implement the multichain interface in coordination with mul
 The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26](https://github.com/MetaMask/SIPs/blob/ed17dd33713e6c2203f11b85ba655ae4acbcca7a/SIPS/sip-26.md) for a high-level overview of the associated architectural approach.
 
 ## Developer Adoption Considerations
-[Explain any considerations that developers should take into account when adopting this proposal. For example, how will it affect compatibility, and what changes may need to be made to accommodate the proposal?]
+Backward compatibility will be maintained through the existing Ethereum Provider API (namely [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326)). However, the Multichain API WILL NOT be available through the existing Ethereum Provider API. Because many developers rely on third-party libraries to connect their applications with wallets, mapping logic that allows them to keep their "single chain" code as-is while actually passing calls on to an underlying Multichain API may facilitate more rapid adoption. 
+
+Given its flexibility and advantages, developers should expect new improvements to the Wallet API to be primarily delivered though the Multichain API, as opposed to the [Ethereum Provider API](https://docs.metamask.io/wallet/reference/provider-api/).
+
+Once there is sufficient industry adoption of the Multichain API, backward-compatibility may be gradually deprecated and discontinued.
 
 ## User Experience Considerations
-[Explain any user experience implications of the proposal]
+Initial calls to the `wallet_authorize` method with `optionalScopes` that include any eip155:[reference] scopes will trigger a flow with this sequence:
+
+```mermaid
+    app->>+MetaMask: wallet_createSession Request
+    actor User
+    MetaMask->>User: Review Default Authorizations
+    activate User
+    User->>MetaMask: Edit Authorizations (optional)
+    User-->>MetaMask: Confirm
+    deactivate User
+    MetaMask-->>-app: wallet_createSession Response
+```
+
+> **Note:** There is no guarantee that an authorization request is surfaced in the wallet as **required**. Your application should gracefully handle situations where some authorizations submitted are denied even though the app is considered connected to MetaMask.
+
+## Privacy Considerations
+This proposal raises important privacy considerations, including the need to avoid data leaking and the challenge of obtaining genuine user consent. It underscores the importance of preserving user anonymity and the sensitivites involved in determining authorizations. Identifying and mitigating these issues is crucial for protecting user privacy during multichain interactions, prompting a careful evaluation of how best to balance functionality with privacy concerns.
 
 ## Security Considerations
-[Explain any potential security implications of the proposal]
+This proposal is an opportunity to further incorporate the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) in MetaMask at least at the API-level.
+
+The proposal also brings to light some security considerations critical to multichain interactions. These include the challenges of ensuring robust authentication and authorization and the importance that users understand the network with which they are interacting. Identifying and addressing these issues is vital for safeguarding users against the evolving landscape of security threats.
 
 ## References
-[List any relevant resources, documentation, or prior art]
+- [CAIP-25](https://chainagnostic.org/CAIPs/caip-25)
+- [CAIP-2](https://chainagnostic.org/CAIPs/caip-2)
+- [CAIP-10](https://chainagnostic.org/CAIPs/caip-10)
+- [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)
+- [CAIP-316](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-316.md)
+- [CAIP-312](https://chainagnostic.org/CAIPs/caip-312)
+- [CAIP-311](https://chainagnostic.org/CAIPs/caip-311)
+- [CAIP-285](https://chainagnostic.org/CAIPs/caip-285)
 
 ### Feedback
 [Provide a way for interested parties to give feedback or make suggestions, such as a GitHub issue or discussion thread]

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -22,7 +22,7 @@ This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement
 Valuable lessons have been learned from scaling the Ethereum dapp and wallet ecosystem. Now, a subset of [CAIPs](https://github.com/ChainAgnostic/CAIPs) offer a path to dramatically improve upon the prevailing patterns that had been established through [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326) with chain-agnostic patterns that address long-standing issues. Furthermore, as decentralized networks continue to diversify, these patterns can be applied to non-EVM ecosystems so they can scale more efficiently and avoid common pain points associated with the demands of a growing dapp ecosystem that may require rapid evolution of Wallet APIs.
 
 The Multichain API and associated CAIP standards promise to enable the following benefits for developers:
-- Ability to interact with non-EVM decentralized networks through a consistent interface
+- Ability to interact with EVM and non-EVM decentralized networks through a consistent interface
 - Ability to use interface negotiation to adopt innovative wallet features, while gracefully degrading for wallets that may not yet support them
 - Ability to simultaneously interact with multiple networks
 - Be notified of updates across multiple networks

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -80,6 +80,7 @@ An example structure for the corresponding JSON-RPC response that a dapp would r
     "sessionScopes": { 
       "eip155:wallet": {
           "methods": ["wallet_addEthereumChain"],
+          "notifications": [],
           "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "eip155:1": {

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -14,8 +14,9 @@ This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement
 
 ### Goals
 - Consistent Structure: Provide common patterns while separating namespaces of each ecosystem or network.
-- Interoperability: Employ standards to encourage the development of powerful libraries with support for multiple wallets and networks
+- Interoperability: Employ standards to encourage the development of powerful libraries with support for multiple wallets and networks.
 - Unlock the Design Space: Enable dapps to negotiate an interface with wallets for optimal multichain experiences.
+- Extensibility: Make the API reasonbaly future-proof, allowing for new networks and methods to be added as demanded by the ecosystem.
 - Security: Enhance security and privacy associated with wallets delived through Browser Extensions.
 
 ## Motivation
@@ -23,7 +24,7 @@ Valuable lessons have been learned from scaling the Ethereum dapp and wallet eco
 
 The Multichain API and associated CAIP standards promise to enable the following benefits for developers:
 - Ability to interact with EVM and non-EVM decentralized networks through a consistent interface
-- Ability to use interface negotiation to adopt innovative wallet features, while gracefully degrading for wallets that may not yet support them
+- Employ interface negotiation patterns to adopt novel wallet features, while gracefully degrading for wallets that may not yet support them
 - Ability to simultaneously interact with multiple networks
 - Be notified of updates across multiple networks
 - Elimination of excessive error handling involved with chain-switching across EVM networks

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -78,7 +78,7 @@ An example structure for the corresponding JSON-RPC response that a dapp would r
   "jsonrpc": "2.0",
   "result": {
     "sessionScopes": { 
-      "eip155:wallet": {
+      "wallet:eip155": {
           "methods": ["wallet_addEthereumChain"],
           "notifications": [],
           "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -45,6 +45,7 @@ An example structure for a JSON-RPC request that a dapp would send to request au
     "optionalScopes": {
       "wallet:eip155": {
         "methods": ["wallet_addEthereumChain"],
+        "notifications": [],
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -162,7 +162,7 @@ An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/ap
 The CAIPs referenced in this proposal are still in Draft or Review status with CASA and may be subject to material changes.
 
 ### API Access
-As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. The current practice for browser extension wallets is to inject a javascript object in order to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
+As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. Currently, browser extension wallets inject a JavaScript object to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
 
 - The MetaMask Browser Extension will adopt an alternative method of communication through the [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable) feature, which is now supported by most modern web browsers with extension frameworks.
 - When a site is accessed through a browser that does not support [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable), the Multichain API will be available through an alternative communication method. 

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -165,7 +165,7 @@ The CAIPs referenced in this proposal are still in Draft or Review status with C
 As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. The current practice for browser extension wallets is to inject a javascript object in order to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
 
 - The MetaMask Browser Extension will adopt an alternative method of communication through the [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable) feature, which is now supported by most modern web browsers with extension frameworks.
-- When a site is accessed through MetaMask's Mobile In-app Browser, the Multichain API will be available through an injected `window.wallet` object. 
+- When a site is accessed through a browser that does not support [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable), the Multichain API will be available through an alternative communication method. 
 
 In summary, the following methods will solely be accessible through the new communication methods:
 `wallet_createSession` (CAIP-25)

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -168,6 +168,7 @@ As part of the Multichain API, MetaMask is leading the adoption of alternative m
 - When a site is accessed through a browser that does not support [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable), the Multichain API will be available through an alternative communication method. 
 
 In summary, the following methods will solely be accessible through the new communication methods:
+
 `wallet_createSession` (CAIP-25)
 `wallet_sessionChanged` (CAIP-311)
 `wallet_getSession` (CAIP-312)
@@ -181,10 +182,11 @@ In summary, the following methods will solely be accessible through the new comm
 Some RPC APIs associated with Snaps will be rendered redundant and will not be supported through the Multichain API. However, they will remain accessible through the EIP-1193 interface for backward compatibility.
 
 **Discontinued Methods:**
-wallet_requestSnaps
-wallet_getSnaps
-wallet_invokeSnap
-wallet_snap
+
+`wallet_requestSnaps`
+`wallet_getSnaps`
+`wallet_invokeSnap`
+`wallet_snap`
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -169,12 +169,12 @@ As part of the Multichain API, MetaMask is leading the adoption of alternative m
 
 In summary, the following methods will solely be accessible through the new communication methods:
 
-`wallet_createSession` (CAIP-25)
-`wallet_sessionChanged` (CAIP-311)
-`wallet_getSession` (CAIP-312)
-`wallet_revokeSession` (CAIP-285)
-`wallet_invokeMethod` (CAIP-27)
-`wallet_notify` (CAIP-319)
+- `wallet_createSession` (CAIP-25)
+- `wallet_sessionChanged` (CAIP-311)
+- `wallet_getSession` (CAIP-312)
+- `wallet_revokeSession` (CAIP-285)
+- `wallet_invokeMethod` (CAIP-27)
+- `wallet_notify` (CAIP-319)
 
 (API Delivery & Wallet Discovery CAIPs to be added in this section)
 
@@ -183,10 +183,10 @@ Some RPC APIs associated with Snaps will be rendered redundant and will not be s
 
 **Discontinued Methods:**
 
-`wallet_requestSnaps`
-`wallet_getSnaps`
-`wallet_invokeSnap`
-`wallet_snap`
+- `wallet_requestSnaps`
+- `wallet_getSnaps`
+- `wallet_invokeSnap`
+- `wallet_snap`
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.
@@ -196,7 +196,7 @@ The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26]
 Dapp developers are encouraged to use libraries to abstract the connection differences between wallet clients and to ensure their dapp stays updated as wallet-to-dapp communication methods continue to evolve.
 
 ## User Experience Considerations
-Initial calls to the `wallet_authorize` method with `optionalScopes` that include any eip155:[reference] scopes will trigger a flow with this sequence:
+Initial calls to the `wallet_createSession` method with `optionalScopes` that include any `eip155:[reference]` scopes will trigger a flow with this sequence:
 
 ```mermaid
   sequenceDiagram

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -197,6 +197,7 @@ Once there is sufficient industry adoption of the Multichain API, backward-compa
 Initial calls to the `wallet_authorize` method with `optionalScopes` that include any eip155:[reference] scopes will trigger a flow with this sequence:
 
 ```mermaid
+  sequenceDiagram
     app->>+MetaMask: wallet_createSession Request
     actor User
     MetaMask->>User: Review Default Authorizations

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -10,7 +10,7 @@ created: 2024-10-28
 ---
 
 ## Summary
-This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement Proposals (CAIPs) to guide the design of a new Wallet API that is generalized for interactions between dapps and wallets in a multichain environment. A "Multichain API". Implementing these standards encourages broad adoption while enhancing interoperability, improving user experiences, and significantly streamlining development for multichain dapps.
+This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement Proposals ([CAIPs](https://github.com/ChainAgnostic/CAIPs)) to guide the design of a new Wallet API that is generalized for interactions between dapps and wallets in a multichain environment. A "Multichain API". Implementing these standards encourages broad adoption while enhancing interoperability, improving user experiences, and significantly streamlining development for multichain dapps.
 
 ### Goals
 - Consistent Structure: Provide common patterns while separating namespaces of each ecosystem or network.

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -161,7 +161,7 @@ The CAIPs referenced in this proposal are still in Draft or Review status with C
 ### API Access
 As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. The current practice for browser extension wallets is to inject a javascript object in order to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
 
-- The MetaMask Browser Extension will adopt an alternative method of communication through the `externally_connectable` feature, which is now supported by most modern web browsers with extension frameworks.
+- The MetaMask Browser Extension will adopt an alternative method of communication through the [externally_connectable](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable) feature, which is now supported by most modern web browsers with extension frameworks.
 - When a site is accessed through MetaMask's Mobile In-app Browser, the Multichain API will be available through an injected `window.wallet` object. 
 
 In summary, the following methods will solely be accessible through the new communication methods:

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -53,7 +53,7 @@ An example structure for a JSON-RPC request that a dapp would send to request au
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
-        "notifications": ["accountChanged"],
+        "notifications": [],
       }
       "bip122:000000000019d6689c085ae165831e93": {
         ...
@@ -90,7 +90,7 @@ An example structure for the corresponding JSON-RPC response that a dapp would r
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
-        "notifications": ["accountChanged"],
+        "notifications": [],
         "accounts": ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv"]
       }
     },      

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -229,12 +229,10 @@ The proposal also brings to light some security considerations critical to multi
 - [CAIP-285](https://chainagnostic.org/CAIPs/caip-285)
 
 ### Feedback
-[Provide a way for interested parties to give feedback or make suggestions, such as a GitHub issue or discussion thread]
+Submit feedback in the [discussion](https://github.com/MetaMask/metamask-improvement-proposals/discussions/53) for this MIP.
 
 ### Committed Developers
-[List the names of developers who have committed to using this proposal in an experimental state. This will help gauge community interest and adoption.]
-
-Note: This proposal template is meant to be adapted for different contexts and may require additional sections or information depending on the specific proposal.
+MetaMask
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE).

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -33,7 +33,7 @@ This proposal also generally encourages a privacy preserving and more secure alt
 ## Usage Example
 
 ### Request
-An example structure for a JSON-RPC request that an application would send to request authorization(s) from MetaMask:
+An example structure for a JSON-RPC request that a dapp would send to request authorization(s) from MetaMask:
 
 ```js
 {
@@ -59,16 +59,16 @@ An example structure for a JSON-RPC request that an application would send to re
     },
     "scopedProperties": {
       // Scope-keyed proposals or declarations
-        "eip155:1": {
-          "extension_foo": "bar"    
-        }
+      "eip155:1": {
+        "extension_foo": "bar"    
+      }
     },
   },
 }
 ```
 
 ### Response
-An example structure for the corresponding JSON-RPC response that an application would receive from the wallet:
+An example structure for the corresponding JSON-RPC response that a dapp would receive from the wallet:
 
 ```js
 {
@@ -108,7 +108,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 **node**: An RPC node that facilitates interactions with a decentralized network.
 
-**Wallet API**: [The JSON-RPC interface](https://docs.metamask.io/wallet/concepts/apis/) that applications can use to programmatically interact with MetaMask wallet clients.
+**Wallet API**: [The JSON-RPC interface](https://docs.metamask.io/wallet/concepts/apis/) that dapps can use to programmatically interact with MetaMask wallet clients.
 
 **authorization**: A permission to access a resource over JSON-RPC.
 
@@ -133,17 +133,17 @@ Multichain API connections will be established and updated through [CAIP-25](htt
 > **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. We only recommend using `optionalScopes`, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized.
 
 ### CAIP-312 - Retrieve Authorization Scopes
-An app can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
+A dapp can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
 
 > **Note:** a `sessionId` parameter is not supported and will be ignored, if included.
 
 ### CAIP-311 - Notification of Changes to Authorization Scopes
-An app can listen for [CAIP-311](https://chainagnostic.org/CAIPs/caip-311) `wallet_sessionChanged` events in order to get notified when there are changes to its authorization scopes.
+A dapp can listen for [CAIP-311](https://chainagnostic.org/CAIPs/caip-311) `wallet_sessionChanged` events in order to get notified when there are changes to its authorization scopes.
 
 > **Note:** A `sessionId` will not be included as part of the event.
 
 ### CAIP-285 - Revoke Authorization Scopes
-An app can make a [CAIP-285](https://chainagnostic.org/CAIPs/caip-285) `wallet_revokeSession` request to revoke all of its authorization scopes.
+A dapp can make a [CAIP-285](https://chainagnostic.org/CAIPs/caip-285) `wallet_revokeSession` request to revoke all of its authorization scopes.
 
 > **Note:** a `sessionId` parameter is not supported and will be ignored, if included.
 
@@ -153,44 +153,57 @@ An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/ap
 ## Caveats
 The CAIPs referenced in this proposal are still in Draft or Review status with CASA and may be subject to material changes.
 
+**API Access:**
+As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. The current practice for browser extension wallets is to inject a javascript object in order to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
+
+- The MetaMask Browser Extension will adopt an alternative method of communication through the `externally_connectable` feature, which is now supported by most modern web browsers with extension frameworks.
+- When a site is accessed through MetaMask's Mobile In-app Browser, the Multichain API will be available through an injected `window.wallet` object. 
+
+In summary, the following methods will solely be accessible through the new communication methods:
+`wallet_createSession` (CAIP-25)
+`wallet_sessionChanged` (CAIP-311)
+`wallet_getSession` (CAIP-312)
+`wallet_revokeSession` (CAIP-285)
+`wallet_invokeMethod` (CAIP-27)
+`wallet_notify` (CAIP-319)
+
+(API Delivery & Wallet Discovery CAIPs to be added in this section)
+
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.
-The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26](https://github.com/MetaMask/SIPs/blob/ed17dd33713e6c2203f11b85ba655ae4acbcca7a/SIPS/sip-26.md) for a high-level overview of the associated architectural approach.
+The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26](https://github.com/MetaMask/SIPs/blob/ed17dd33713e6c2203f11b85ba655ae4acbcca7a/SIPS/sip-26.md) for a high-level overview of the anticipated architectural approach.
 
 ## Developer Adoption Considerations
-Backward compatibility will be maintained through the existing Ethereum Provider API (namely [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326)). However, the Multichain API WILL NOT be available through the existing Ethereum Provider API. Because many developers rely on third-party libraries to connect their applications with wallets, mapping logic that allows them to keep their "single chain" code as-is while actually passing calls on to an underlying Multichain API may facilitate more rapid adoption. 
-
-Given its flexibility and advantages, developers should expect new improvements to the Wallet API to be primarily delivered though the Multichain API, as opposed to the [Ethereum Provider API](https://docs.metamask.io/wallet/reference/provider-api/).
-
-Once there is sufficient industry adoption of the Multichain API, backward-compatibility may be gradually deprecated and discontinued.
+dapp developers are encouraged to use libraries to abstract the connection differences between wallet clients and to ensure their dapp stays updated as wallet-to-dapp communication methods continue to evolve.
 
 ## User Experience Considerations
 Initial calls to the `wallet_authorize` method with `optionalScopes` that include any eip155:[reference] scopes will trigger a flow with this sequence:
 
 ```mermaid
   sequenceDiagram
-    app->>+MetaMask: wallet_createSession Request
+    dapp->>+MetaMask: wallet_createSession Request
     actor User
     MetaMask->>User: Review Default Authorizations
     activate User
     User->>MetaMask: Edit Authorizations (optional)
     User-->>MetaMask: Confirm
     deactivate User
-    MetaMask-->>-app: wallet_createSession Response
+    MetaMask-->>-dapp: wallet_createSession Response
 ```
 
-> **Note:** There is no guarantee that an authorization request is surfaced in the wallet as **required**. Your application should gracefully handle situations where some authorizations submitted are denied even though the app is considered connected to MetaMask.
+> **Note:** There is no guarantee that an authorization request is surfaced in the wallet as **required**. Your application should gracefully handle situations where some authorizations submitted are denied even though the dapp may be considered to be connected to MetaMask.
 
 ## Privacy Considerations
-This proposal raises important privacy considerations, including the need to avoid data leaking and the challenge of obtaining genuine user consent. It underscores the importance of preserving user anonymity and the sensitivites involved in determining authorizations. Identifying and mitigating these issues is crucial for protecting user privacy during multichain interactions, prompting a careful evaluation of how best to balance functionality with privacy concerns.
+It has become common for Browser Extension Wallets to require permissions that allow the extension to read and change all data on websites a user visits. Unfortunately, such a permissive privilege poses end-users with a significant risk to their privacy. While much of the ecosystem is now dependent on this pattern, we encourage web browsers, other wallets, and dapp builders to move in a the direction of avoiding such onerous browser extension permissions altogether.
 
 ## Security Considerations
-This proposal is an opportunity to further incorporate the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) in MetaMask at least at the API-level.
+This proposal is an opportunity to further incorporate the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) in MetaMask at least at the API-level. [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) is specifically designed around this principle.
 
 The proposal also brings to light some security considerations critical to multichain interactions. These include the challenges of ensuring robust authentication and authorization and the importance that users understand the network with which they are interacting. Identifying and addressing these issues is vital for safeguarding users against the evolving landscape of security threats.
 
 ## References
 - [CAIP-25](https://chainagnostic.org/CAIPs/caip-25)
+- [CAIP-27](https://chainagnostic.org/CAIPs/caip-27)
 - [CAIP-2](https://chainagnostic.org/CAIPs/caip-2)
 - [CAIP-10](https://chainagnostic.org/CAIPs/caip-10)
 - [CAIP-217](https://chainagnostic.org/CAIPs/caip-217)

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -48,7 +48,7 @@ An example structure for a JSON-RPC request that a dapp would send to request au
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
@@ -83,7 +83,7 @@ An example structure for the corresponding JSON-RPC response that a dapp would r
       },
       "eip155:1": {
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
+        "notifications": ["eth_subscription"],
         "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
@@ -131,7 +131,9 @@ Multichain API connections will be established and updated through [CAIP-25](htt
 
 > **Note:** A `sessionId` will not be returned in the initial response. Instead, the API will adopt session lifecycle management methods outlined in [CAIP-316](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-316.md)
 
-> **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. Only `optionalScopes` are recommended, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized. 
+> **Note:** MetaMask treats `requiredScopes` as `optionalScopes`. Only `optionalScopes` are recommended, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized. 
+
+> **Note:** Developers are encouraged to precisely request only the authorization scopes for methods and notifications that their dapp expects to call before making additional `wallet_createSession` calls to expand authorization scopes. Requesting specific authorization scopes allows wallets to discover and implement features that are being adopted. Wallets can also further optimize permission confirmation flows to reduce unnecessary friction for some method calls. For simplicity, however, MetaMask may return more authorization scopes, methods, or notifications than the caller explicitly requested.
 
 ### CAIP-27 - Invoke RPC Requests for an Authorization Scope
 A dapp can invoke RPC requests for an authorization scope by making [CAIP-27](https://chainagnostic.org/CAIPs/caip-27) `wallet_invokeMethod` calls.

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -132,6 +132,11 @@ Multichain API connections will be established and updated through [CAIP-25](htt
 
 > **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. Only `optionalScopes` are recommended, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized. 
 
+### CAIP-27 - Invoke RPC Requests for an Authorization Scope
+A dapp can invoke RPC requests for an authorization scope by making [CAIP-27](https://chainagnostic.org/CAIPs/caip-27) `wallet_invokeMethod` calls.
+
+> **Note:** a `sessionId` parameter is not supported and will be ignored, if included.
+
 ### CAIP-312 - Retrieve Authorization Scopes
 A dapp can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
 

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -1,0 +1,208 @@
+---
+mip: x
+title: Adopt chain agnostic standards for a Multichain API
+status: Draft
+stability: n/a
+discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions/53
+Authors: Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
+type: Maintainer
+created: 2024-10-28
+---
+
+## Summary
+This proposal recommends that MetaMask adopt a set of Chain Agnostic Improvement Proposals (CAIPs) to guide the design of a new Wallet API that is generalized for interactions between dapps and wallets in a multichain environment. A "Multichain API". Implementing these standards encourages broad adoption while enhancing interoperability, improving user experiences, and significantly streamlining development for multichain dapps.
+
+### Goals
+- Consistent Structure: Provide common patterns while separating namespaces of each ecosystem or network.
+- Interoperability: Employ standards to encourage the development of powerful libraries with support for multiple wallets and networks
+- Unlock the Design Space: Enable dapps to negotiate an interface with wallets for optimal multichain experiences.
+- Security: Enhance security and privacy associated with wallets delived through Browser Extensions.
+
+## Motivation
+Valuable lessons have been learned from scaling the Ethereum dapp and wallet ecosystem. Now, a subset of [CAIPs](https://github.com/ChainAgnostic/CAIPs) offer a path to dramatically improve upon the prevailing patterns that had been established through [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-3326](https://eips.ethereum.org/EIPS/eip-3326) with chain-agnostic patterns that address long-standing issues. Furthermore, as decentralized networks continue to diversify, these patterns can be applied to non-EVM ecosystems so they can scale more efficiently and avoid common pain points associated with the demands of a growing dapp ecosystem that may require rapid evolution of Wallet APIs.
+
+The Multichain API and associated CAIP standards promise to enable the following benefits for developers:
+- Ability to interact with non-EVM decentralized networks through a consistent interface
+- Ability to use interface negotiation to adopt innovative wallet features, while gracefully degrading for wallets that may not yet support them
+- Ability to simultaneously interact with multiple networks
+- Be notified of updates across multiple networks
+- Elimination of excessive error handling involved with chain-switching across EVM networks
+
+This proposal also generally encourages a privacy preserving and more secure alternative to provider injection (ex. `window.<provider>`) to establish communication between sites and browser extension wallets. 
+
+## Usage Example
+
+### Request
+An example structure for a JSON-RPC request that an application would send to request authorization(s) from MetaMask:
+
+```js
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_createSession",
+  "params": {
+    "optionalScopes": {
+      "wallet:eip155": {
+        "methods": ["wallet_addEthereumChain"],
+      },
+      "eip155:1": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+      },
+      "eip155:59144": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+      },
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+        "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
+        "notifications": ["accountChanged"],
+      }
+      "bip122:000000000019d6689c085ae165831e93": {
+        ...
+      }
+    },
+    "scopedProperties": {
+      "eip155:1": {
+        "rpcEndpoints": [{ 
+          "chainName": "Ethereum (Infura)",
+          "rpcUrls": ["https://mainnet.infura.io"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+          "iconURLs": ["https://example.com/ethereum.svg"] 
+        }],  
+      },
+      "eip155:59144": {
+        "rpcEndpoints": [{ 
+          "chainName": "Linea (Infura)",
+          "rpcUrls": ["https://rpc.linea.build"],
+          "nativeCurrency": {
+              "name": "ETH",
+              "symbol": "ETH",
+              "decimals": 18,
+          },
+          "iconURLs": ["https://example.com/linea.svg"] 
+        }],
+      },
+    },
+  },
+}
+```
+
+### Response
+An example structure for the corresponding JSON-RPC response that an application would receive from the wallet:
+
+```js
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "sessionScopes": { 
+      "eip155:wallet": {
+          "methods": ["wallet_addEthereumChain"],
+          "accounts": ["eip155:wallet:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "eip155:1": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+        "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "eip155:59144": {
+        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
+        "notifications": ["message"],
+        "accounts": ["eip155:59144:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+        "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
+        "notifications": ["accountChanged"],
+        "accounts": ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv"]
+      }
+    },      
+  }
+}
+```
+
+# Proposal
+
+## Language
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" written in uppercase in this document are to be interpreted as described in RFC 2119.
+
+## Definitions
+
+**Multichain API**: a new [Wallet API](https://docs.metamask.io/wallet/concepts/wallet-api/) that is generalized for interactions between dapps and wallets in a multichain environment
+
+**network**: Decentralized networks where control, validation, and decision-making processes are distributed across multiple nodes rather than centralized in a single entity. The term will refer to a specific decentralized network that has a single unique identifier. Networks may be implemented as a blockchain or another distributed ledger technology. 
+
+**node**: An RPC node that facilitates interactions with a decentralized network.
+
+**Wallet API**: [The JSON-RPC interface](https://docs.metamask.io/wallet/concepts/apis/) that applications can use to programmatically interact with MetaMask wallet clients.
+
+**authorization**: A permission to access a resource over JSON-RPC.
+
+**scope**: A uniquely identified domain for which authorizations can be applied (see [CAIP-217](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-217.md) for further definition). 
+
+**authorization scopes**: A set of objects that specify authorizations for each scope.
+
+## Proposal Specification
+
+As part of MetaMask's Multichain API implementation, MetaMask will adopt the following standards with notes for implementation-specific guidelines or differences:
+
+### CAIP-2 - Network Identifiers
+The network identifiers used in the routing of Multichain API calls will follow [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) conventions and [namespaces](https://namespaces.chainagnostic.org/).
+
+> **Note:** Supported namespaces may be limited. Consult the [MetaMask documentation](https://docs.metamask.io/wallet/reference/multichain-api) for the most up-to-date information.
+
+### CAIP-25 - Negotiate Multichain Authorization Scopes
+Multichain API connections will be established and updated through [CAIP-25](https://chainagnostic.org/CAIPs/caip-25) `wallet_createSession` calls.
+
+> **Note:** A `sessionId` will not be returned in the initial response. Instead, the API will adopt session lifecycle management methods outlined in [CAIP-316](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-316.md)
+
+### CAIP-312 - Retrieve Authorization Scopes
+An app can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
+
+> **Note:** a `sessionId` parameter is not supported and will be ignored, if included.
+
+### CAIP-311 - Notification of Changes to Authorization Scopes
+An app can listen for [CAIP-311](https://chainagnostic.org/CAIPs/caip-311) `wallet_sessionChanged` events in order to get notified when there are changes to its authorization scopes.
+
+> **Note:** A `sessionId` will not be included as part of the event.
+
+### CAIP-285 - Revoke Authorization Scopes
+An app can make a [CAIP-285](https://chainagnostic.org/CAIPs/caip-285) `wallet_revokeSession` request to revoke all of its authorization scopes.
+
+> **Note:** a `sessionId` parameter is not supported and will be ignored, if included.
+
+### API Specification Document
+An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/api-specs/blob/main/multichain/openrpc.yaml) can be found in the [api-specs](https://github.com/MetaMask/api-specs) repository.
+
+## Caveats
+The CAIPs referenced in this proposal are still in Draft or Review status with CASA and may be subject to material changes.
+
+## Implementation
+API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.
+The Multichain API is intended to interoperate with MetaMask Snaps. See [SIP-26](https://github.com/MetaMask/SIPs/blob/ed17dd33713e6c2203f11b85ba655ae4acbcca7a/SIPS/sip-26.md) for a high-level overview of the associated architectural approach.
+
+## Developer Adoption Considerations
+[Explain any considerations that developers should take into account when adopting this proposal. For example, how will it affect compatibility, and what changes may need to be made to accommodate the proposal?]
+
+## User Experience Considerations
+[Explain any user experience implications of the proposal]
+
+## Security Considerations
+[Explain any potential security implications of the proposal]
+
+## References
+[List any relevant resources, documentation, or prior art]
+
+### Feedback
+[Provide a way for interested parties to give feedback or make suggestions, such as a GitHub issue or discussion thread]
+
+### Committed Developers
+[List the names of developers who have committed to using this proposal in an experimental state. This will help gauge community interest and adoption.]
+
+Note: This proposal template is meant to be adapted for different contexts and may require additional sections or information depending on the specific proposal.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -130,7 +130,7 @@ Multichain API connections will be established and updated through [CAIP-25](htt
 
 > **Note:** A `sessionId` will not be returned in the initial response. Instead, the API will adopt session lifecycle management methods outlined in [CAIP-316](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-316.md)
 
-> **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. We only recommend using `optionalScopes`, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized.
+> **Note:**  MetaMask treats `requiredScopes` as `optionalScopes`. Only `optionalScopes` are recommended, though `requiredScopes` can be used to signal that your dapp will not be usable if certain [CAIP-217](https://chainagnostic.org/CAIPs/caip-217) `scopeStrings` are not authorized. 
 
 ### CAIP-312 - Retrieve Authorization Scopes
 A dapp can retrieve a [CAIP-312](https://chainagnostic.org/CAIPs/caip-312) multichain session object by calling `wallet_getSession` to request its authorization scopes at any time.
@@ -153,7 +153,7 @@ An OpenRPC [specification for the Multichain API](https://github.com/MetaMask/ap
 ## Caveats
 The CAIPs referenced in this proposal are still in Draft or Review status with CASA and may be subject to material changes.
 
-**API Access:**
+### API Access
 As part of the Multichain API, MetaMask is leading the adoption of alternative methods for browser extension wallet communication. The current practice for browser extension wallets is to inject a javascript object in order to communicate with each site. But this approach comes with privacy, security, reliability, and performance drawbacks.
 
 - The MetaMask Browser Extension will adopt an alternative method of communication through the `externally_connectable` feature, which is now supported by most modern web browsers with extension frameworks.
@@ -168,6 +168,15 @@ In summary, the following methods will solely be accessible through the new comm
 `wallet_notify` (CAIP-319)
 
 (API Delivery & Wallet Discovery CAIPs to be added in this section)
+
+### Snap Methods
+Some RPC APIs associated with Snaps will be rendered redundant and will not be supported through the Multichain API. However, they will remain accessible through the EIP-1193 interface for backward compatibility.
+
+**Discontinued Methods:**
+wallet_requestSnaps
+wallet_getSnaps
+wallet_invokeSnap
+wallet_snap
 
 ## Implementation
 API Maintainers will implement the multichain interface in coordination with multiple MetaMask teams.

--- a/MIPs/mip-x-multichainapi.md
+++ b/MIPs/mip-x-multichainapi.md
@@ -4,7 +4,7 @@ title: Adopt chain agnostic standards for a Multichain API
 status: Draft
 stability: n/a
 discussions-to: https://github.com/MetaMask/metamask-improvement-proposals/discussions/53
-Authors: Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
+author(s): Alex Donesky (@adonesky1), Jiexi Luan (@jiexi), Vandan Parikh(@vandan) 
 type: Maintainer
 created: 2024-10-28
 ---
@@ -49,10 +49,6 @@ An example structure for a JSON-RPC request that an application would send to re
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
         "notifications": ["message"],
       },
-      "eip155:59144": {
-        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
-      },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],
         "notifications": ["accountChanged"],
@@ -62,30 +58,10 @@ An example structure for a JSON-RPC request that an application would send to re
       }
     },
     "scopedProperties": {
-      "eip155:1": {
-        "rpcEndpoints": [{ 
-          "chainName": "Ethereum (Infura)",
-          "rpcUrls": ["https://mainnet.infura.io"],
-          "nativeCurrency": {
-              "name": "ETH",
-              "symbol": "ETH",
-              "decimals": 18,
-          },
-          "iconURLs": ["https://example.com/ethereum.svg"] 
-        }],  
-      },
-      "eip155:59144": {
-        "rpcEndpoints": [{ 
-          "chainName": "Linea (Infura)",
-          "rpcUrls": ["https://rpc.linea.build"],
-          "nativeCurrency": {
-              "name": "ETH",
-              "symbol": "ETH",
-              "decimals": 18,
-          },
-          "iconURLs": ["https://example.com/linea.svg"] 
-        }],
-      },
+      // Scope-keyed proposals or declarations
+        "eip155:1": {
+          "extension_foo": "bar"    
+        }
     },
   },
 }
@@ -108,11 +84,6 @@ An example structure for the corresponding JSON-RPC response that an application
         "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
         "notifications": ["message"],
         "accounts": ["eip155:1:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
-      },
-      "eip155:59144": {
-        "methods": ["eth_sendTransaction","eth_call","eth_getBalance","eth_blockNumber","eth_getTransactionCount","wallet_watchAsset","eth_subscribe"],
-        "notifications": ["message"],
-        "accounts": ["eip155:59144:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signAndSendTransaction","signAllTransactions","signMessage"],


### PR DESCRIPTION
These MIPs are meant to add context to the Chain Agnostic Standards that are proposed for adoption.

mip-x-multichainapi.md - Describes the purpose behind the adoption of a Multichain API generally (chain agnostic). It also provides detail about implementation differences and guidelines that are not part of the referenced CAIPs.
mip-x-evmmultichainapi.md - Provides detail about Ethereum-specific implementation differences and guidelines that are not part of the referenced CAIPs.